### PR TITLE
Avoid shipping specs in archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/spec export-ignore
+.* export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 /spec export-ignore
 .* export-ignore
+composer.lock export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: php
 
+env:
+  global:
+    - XDEBUG_MODE=coverage
+
 php:
   - 7.2
   - 7.3


### PR DESCRIPTION
By adding a `.gitattributes`-file, we can tell Git to ignore
files not necessary for third parties, like our specs and dot-files.