### PR TITLE
Test env variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ script:
   - composer run analyse
 
 after_success:
+  - env
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
> You can determine the keys and tokens that are surfaced to your CI environment by running the env command in your CI pipeline.
> If anything returned from that command is considered private or sensitive, we strongly recommend invalidating the credential and generating a new one. 